### PR TITLE
Fix typo in update hook

### DIFF
--- a/src/update
+++ b/src/update
@@ -64,7 +64,7 @@ aws_hooks_md5 = execute "aws hooks md5" do
       -f \
       -k \
       https://d1ormdui8qdvue.cloudfront.net/hooks/logvac-stable.md5 \
-        | tee /tmp/hooks.md5'
+        | tee /tmp/hooks.md5
   END
 end
 
@@ -75,7 +75,7 @@ if local_hooks_md5 != aws_hooks_md5
         -f \
         -k \
         https://d1ormdui8qdvue.cloudfront.net/hooks/logvac-stable.tgz \
-          | tar -xz -C /opt/nanobox/hooks'
+          | tar -xz -C /opt/nanobox/hooks
     END
   end
 


### PR DESCRIPTION
Prevents `unterminated quoted string` errors